### PR TITLE
update macOS instructions for current brew

### DIFF
--- a/Linux-Instructions.md
+++ b/Linux-Instructions.md
@@ -19,6 +19,5 @@ Install the [Brew Package Manager](https://brew.sh/) Using Terminal:
 Install necessary packages:
 
 ```bash
-brew cask install android-platform-tool
-brew install wget zenity
+brew install android-platform-tool wget zenity
 ```


### PR DESCRIPTION
`brew cask` is no longer available. Running on Homebrew 3.3.12 the instructions failed but a regular `brew install` works.