### PR TITLE
23.09

### DIFF
--- a/Fire-Tools/Debloat.txt
+++ b/Fire-Tools/Debloat.txt
@@ -51,6 +51,7 @@ com.amazon.fireos.cirruscloud                    # Cirrus Cloud
 com.amazon.connectivitydiag                      # Connectivity Diagnostics
 com.android.contacts                             # Contacts
 com.android.providers.contacts                   # Contacts Storage
+com.android.providers.partnerbookmarks           # Provider Bookmarks
 com.amazon.dp.contacts                           # Contacts Sync Adapter
 com.amazon.providers.contentsupport              # Content Support Manager
 com.amazon.sync.service                          # Content Sync Framework

--- a/Fire-Tools/debloat.sh
+++ b/Fire-Tools/debloat.sh
@@ -19,7 +19,7 @@ opt=$(zenity --list \
 --column="Option" --column="Description" \
     "Enable" "Enable all Amazon apps" \
     "Disable" "Disable Amazon bloat" \
-    "Custom" "Disable selected packages" \
+    "Custom" "Enable/Disable selected packages" \
     "Edit" "Open Debloat.txt in a text editor")
 
 # Debloat & Package List
@@ -73,10 +73,12 @@ case "$opt" in
     "Custom")
         packages=$(adb shell pm list packages | cut -f2 -d:)
         list=$(zenity --list --width=500 --height=400 --column=Packages --multiple $packages | tr '|' '\n')
-        custom=$(zenity --list --width=500 --height=400 --title="Enable/Disable Selected Packages" --column=Option "Enable" "Disable")
-        for package in ${list}; do
-            debloat "$custom" "$package"
-        done;;
+        [ -n "$list" ] && {
+            custom=$(zenity --list --width=500 --height=400 --title="Enable/Disable Selected Packages" --column=Option "Enable" "Disable")
+            for package in ${list}; do
+                debloat "$custom" "$package"
+            done
+        };;
 
     "Edit")
         [ "$OSTYPE" = "darwin"  ] && { open -e ./Debloat.txt; exec ./debloat.sh; }

--- a/Fire-Tools/debloat.sh
+++ b/Fire-Tools/debloat.sh
@@ -71,10 +71,11 @@ case "$opt" in
         fi;;
     
     "Custom")
-        packages=$(adb shell pm list packages -e | cut -f2 -d:)
+        packages=$(adb shell pm list packages | cut -f2 -d:)
         list=$(zenity --list --width=500 --height=400 --column=Packages --multiple $packages | tr '|' '\n')
+        custom=$(zenity --list --width=500 --height=400 --title="Enable/Disable Selected Packages" --column=Option "Enable" "Disable")
         for package in ${list}; do
-            debloat "Disable" "$package"
+            debloat "$custom" "$package"
         done;;
 
     "Edit")

--- a/Fire-Tools/debloat.sh
+++ b/Fire-Tools/debloat.sh
@@ -7,7 +7,7 @@ case "$1" in
         adb shell pm enable "$2" 2> /dev/null ||
         echo "Failed to Enable: $2";;
     Disable)
-        adb shell pm disable-user -k "$2" 2> /dev/null ||
+        adb shell pm disable-user "$2" 2> /dev/null && adb shell pm clear "$2" > /dev/null ||
         echo "Failed to Disable: $2";;
 esac
 }

--- a/Fire-Tools/debloat.sh
+++ b/Fire-Tools/debloat.sh
@@ -49,7 +49,6 @@ case "$opt" in
             adb shell settings put secure limit_ad_tracking 1
             adb shell settings put secure usage_metrics_marketing_enabled 0
             adb shell settings put secure USAGE_METRICS_UPLOAD_ENABLED 0
-            adb shell pm clear com.amazon.advertisingidsettings
             echo "Disabling Location"
             adb shell settings put secure location_providers_allowed -network
             echo "Blocking Ads With Adguard DNS"

--- a/Fire-Tools/launcher.sh
+++ b/Fire-Tools/launcher.sh
@@ -34,6 +34,7 @@ launcher=$(diff installed* | grep -E -o "[a-z0-9]*(\.[a-z0-9]+)+[a-z0-9]")
     adb shell appwidget grantbind --package "$launcher"
     rm installed* --force
     adb shell pm disable-user -k com.amazon.firelauncher
+    adb shell input keyevent KEYCODE_HOME
     echo "Installed Launcher: $launcher"
 }
 

--- a/Fire-Tools/ui.sh
+++ b/Fire-Tools/ui.sh
@@ -2,16 +2,16 @@
 
 version="23.09"
 
+# Check for Dependencies
+export dependencies="adb zenity"
+for dependency in ${dependencies}; do
+    "$dependency" --version >/dev/null || { printf "%s\n" "Error Dependency Required: $dependency"; exit 1; }
+done
+
 # Wait for Device
 adb get-state > /dev/null 2>&1 ||
 printf "Please Connect a Fire Tablet\nWaiting for Device...\n\n"
 adb wait-for-device
-
-# Check for Dependencies
-export dependencies="adb zenity"
-for dependency in ${dependencies}; do
-    "$dependency" --version >/dev/null || { echo "Error Dependency Required: $dependency"; exit 1; }
-done
 
 # If Device is Running Fire OS Identify Using Amazon Docs Page (Cache Until Next Update)
 device="Unknown/Unsupported"
@@ -20,8 +20,7 @@ if (adb shell pm list features | grep -q "fireos"); then
     [ -e ft-identifying-tablet-devices.html ] || curl -O "https://developer.amazon.com/docs/fire-tablets/ft-identifying-tablet-devices.html"
     device=$(grep -B 2 "$model" < ft-identifying-tablet-devices.html | grep -E -o "(Kindle|Fire) (.*?)[G|g]en\)")
     fireos=$(adb shell getprop ro.build.version.name | grep -E -o "Fire OS (.*?)\.[1-9] ")
-    echo "Device Detected: $device"
-    echo "Software Version: $fireos\n"
+    printf "Device: %s\nSoftware: %s\n\n" "$device" "$fireos"
 fi
 
 # Change Application Installation Method Based on Filetype
@@ -65,8 +64,8 @@ case "$tool" in
         done
         appinstaller ./Gapps/*Store*
         installed=$(adb shell pm list packages com.android.vending)
-        [ -n "$installed" ] && echo "Successfully Installed Google Apps" ||
-        echo "Failed to Install Google Apps";;
+        [ -n "$installed" ] && printf "%s\n" "Successfully Installed Google Apps" ||
+        printf "%s\n" "Failed to Install Google Apps";;
 
     "Change Launcher")
         exec ./launcher.sh;;
@@ -74,15 +73,15 @@ case "$tool" in
     "Disable OTA")
         export ota="com.amazon.device.software.ota com.amazon.device.software.ota.override com.amazon.kindle.otter.oobe.forced.ota"
         for package in ${ota}; do
-            adb shell pm disable-user -k "$package" || { echo "Failed to Disable OTA Updates"; exec ./ui.sh; }
+            adb shell pm disable-user -k "$package" || { printf "%s\n" "Failed to Disable OTA Updates"; exec ./ui.sh; }
         done
-        echo "Successfully Disabled OTA Updates";;
+        printf "%s\n" "Successfully Disabled OTA Updates";;
 
     "Apk Extractor")
         packages=$(adb shell pm list packages | cut -f2 -d:)
         list=$(zenity --list --width=500 --height=400 --column=Packages  --multiple $packages | tr '|' '\n')
         for package in ${list}; do
-            echo "Extracting: $package"
+            printf "%s\n" "Extracting: $package"
             mkdir -p ./Extracted/"$package"
             adb shell pm path "$package" | cut -f2 -d: | xargs -I % adb pull % ./Extracted/"$package"
         done;;
@@ -92,36 +91,36 @@ case "$tool" in
         do
             appinstaller "$app"
         done
-        echo "Finished Installing App(s)";;
+        printf "%s\n" "Finished Installing App(s)";;
 
     "Custom DNS")
         server=$(zenity --entry --width=400 --height=200 --title="Input Private DNS (DoT) Provider" --text="Example Servers:\n- dns.adguard.com\n- security.cloudflare-dns.com\n- dns.quad9.net\n- None")
-        echo "$server" | grep -q --ignore-case "None" && {
+        printf "%s\n" "$server" | grep -q --ignore-case "None" && {
             adb shell settings put global private_dns_mode -hostname
             exec ./ui.sh
-            echo "Disabled Private DNS"
+            printf "%s\n" "Disabled Private DNS"
         }
-        echo "$server" | grep -q "dns" &&
+        printf "%s\n" "$server" | grep -q "dns" &&
         if (ping -q -c 1 "$server" > /dev/null 2>&1); then
             adb shell settings put global private_dns_mode hostname
             adb shell settings put global private_dns_specifier "$server"
-            echo "Successfully Changed Private DNS to: $server"
+            printf "%s\n" "Successfully Changed Private DNS to: $server"
         else
-            echo "Error: $server is Not a Valid DoT Address"
+            printf "%s\n" "Error: $server is Not a Valid DoT Address"
         fi;;
 
     "Update")
         latest=$(curl -sSL https://github.com/mrhaydendp/Fire-Tools/raw/main/Fire-Tools/version | cut -c 1,2,4,5)
-        version=$(echo "$version" | cut -c 1,2,4,5)
+        version=$(printf "%s\n" "$version" | cut -c 1,2,4,5)
         [ "$version" -lt "$latest" ] && {
-        echo "Latest Changelogs:" && curl -sSL https://github.com/mrhaydendp/Fire-Tools/raw/main/Changelog.md
+        printf "%s\n" "Latest Changelogs:" && curl -sSL https://github.com/mrhaydendp/Fire-Tools/raw/main/Changelog.md
         export modules="Debloat.txt ui.sh debloat.sh launcher.sh"
         for module in ${modules}; do
             curl -LO "https://github.com/mrhaydendp/Fire-Tools/raw/main/Fire-Tools/$module"
         done
         rm ./ft-identifying-tablet-devices.html --force
-        echo "Successfully Updated, Reloading Application..."
-        } || echo "No Updates Available";;
+        printf "%s\n" "Successfully Updated, Reloading Application..."
+        } || printf "%s\n" "No Updates Available";;
 esac
 
 # Exit to Menu When a Tool Finishes

--- a/Fire-Tools/ui.sh
+++ b/Fire-Tools/ui.sh
@@ -9,7 +9,7 @@ for dependency in ${dependencies}; do
 done
 
 # Wait for Device
-adb get-state > /dev/null 2>&1 ||
+adb get-state >/dev/null 2>&1 ||
 printf "Please Connect a Fire Tablet\nWaiting for Device...\n\n"
 adb wait-for-device
 
@@ -25,14 +25,16 @@ fi
 
 # Change Application Installation Method Based on Filetype
 appinstaller () {
+    printf "%s\n" "Installing: $1"
     case "$1" in
     *.apk)
-        adb install -g "$1";;
+        adb install -g "$1" >/dev/null 2>&1;;
     *.apkm)
         unzip "$1" -d ./Split >/dev/null
-        adb install-multiple -r -g ./Split/*.apk
+        adb install-multiple -r -g ./Split/*.apk >/dev/null 2>&1
         rm -rf ./Split;;
     esac
+    [ "$?" = 0 ] && printf "%s\n" "Success" || printf "%s\n" "Fail"
 }
 
 # Invoke Tools by Adding Their Names After ./ui.sh (Ex: ./ui.sh Update) Else, Resort to UI
@@ -101,7 +103,7 @@ case "$tool" in
             printf "%s\n" "Disabled Private DNS"
         }
         printf "%s\n" "$server" | grep -q "dns" &&
-        if (ping -q -c 1 "$server" > /dev/null 2>&1); then
+        if (ping -q -c 1 "$server" >/dev/null 2>&1); then
             adb shell settings put global private_dns_mode hostname
             adb shell settings put global private_dns_specifier "$server"
             printf "%s\n" "Successfully Changed Private DNS to: $server"

--- a/Fire-Tools/ui.sh
+++ b/Fire-Tools/ui.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env sh
 
-version="23.08"
+version="23.09"
+
+# Wait for Device
+adb get-state > /dev/null 2>&1 ||
+printf "Please Connect a Fire Tablet\nWaiting for Device...\n\n"
+adb wait-for-device
 
 # Check for Dependencies
 export dependencies="adb zenity"


### PR DESCRIPTION
- Version bump (23.09)
- Script now waits for a device to be connected
- Swapping to printf for better Posix compatibility & multi-line support (Linux/macOS)
- You are now sent home after installing a new launcher
- App data will now get cleared during debloat process
- Packages selected from the Custom menu can now be enabled or disabled
- Added "Provider Bookmarks" to debloat list