### PR TITLE
Add nix flake to make project easy to setup / run on systems that have nix

### DIFF
--- a/Fire-Tools/main.py
+++ b/Fire-Tools/main.py
@@ -7,12 +7,14 @@ import customtkinter as ctk
 # Platform & Device Variables
 version = "24.06"
 platform = "Linux/macOS"
-path = f"{os.getcwd()}/Scripts/Posix/"
+appdir = os.path.dirname(os.path.abspath(__file__))
+path = f"{appdir}/Scripts/Posix/"
+
 extension = ".sh"
 shell = "Posix"
 if os.name == "nt":
     platform = "Windows"
-    path = f"powershell -ExecutionPolicy Bypass -file {os.getcwd()}\\Scripts\\PowerShell\\"
+    path = f"powershell -ExecutionPolicy Bypass -file {appdir}\\Scripts\\PowerShell\\"
     extension = ".ps1"
     shell = "PowerShell"
 
@@ -58,7 +60,7 @@ def update_tool():
             with open(f"{module}", "wb") as file:
                 file.write(requests.get(f"https://github.com/mrhaydendp/Fire-Tools/raw/main/Fire-Tools/{module}", timeout=10).content)
         if platform == "Linux/macOS":
-            for script in glob.glob(f"{os.getcwd()}/Scripts/Posix/*.sh"):
+            for script in glob.glob(f"{appdir}/Scripts/Posix/*.sh"):
                 os.chmod(script, 0o775 )
         print("\nUpdates Complete, Please Re-launch Application")
         quit()

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1720542800,
+        "narHash": "sha256-ZgnNHuKV6h2+fQ5LuqnUaqZey1Lqqt5dTUAiAnqH0QQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "feb2849fdeb70028c70d73b848214b00d324a497",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,81 @@
+{
+	description = "Tools for debloating and installing Google Play Services on Fire Tablets + More!";
+
+	inputs = {
+		nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+	};
+
+	outputs = { self, nixpkgs }: let
+
+	supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+	forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+	pythonDependencies = (python-pkgs: with python-pkgs; [
+		certifi
+		charset-normalizer
+		customtkinter
+		darkdetect
+		packaging
+		requests
+		tkinter
+		urllib3
+	]);
+
+	in {
+		devShells = forAllSystems (system: let
+			pkgs = nixpkgs.legacyPackages.${system};
+			pythonWithDeps = pythonDependencies pkgs.python311Packages;
+		in {
+			default = pkgs.mkShellNoCC {
+				packages = with pkgs; [ android-tools pythonWithDeps ];
+			};
+		});
+
+		apps = forAllSystems (system: {
+			default = {
+				type = "app";
+				program = "${self.packages.${system}.fire-tools}/bin/fire-tools";
+			};
+		});
+
+		packages = forAllSystems (system: let
+			pkgs = nixpkgs.legacyPackages.${system};
+			pythonWithDeps = pkgs.python3.withPackages pythonDependencies;
+		in {
+			default = self.packages.${system}.fire-tools;
+
+			fire-tools = pkgs.stdenv.mkDerivation {
+				pname = "Fire-Tools";
+				version = builtins.readFile ./Fire-Tools/version;
+				src = ./Fire-Tools;
+
+				propogatedBuildInputs = with pkgs; [ android-tools pythonWithDeps ];
+
+				buildPhase = "";
+				installPhase = ''
+					# Copy source files
+					mkdir -p $out/src
+					cp -R * $out/src
+
+					# Create bin dir
+					mkdir -p $out/bin
+
+					# Create shell script to execute python script
+					echo '#!/bin/sh' > $out/bin/fire-tools
+					echo "exec ${pythonWithDeps.interpreter} $out/src/main.py \$@" >> $out/bin/fire-tools
+
+					# Make bin and scripts executable
+					find $out/src -type f -name '*.sh' -exec chmod +x {} \;
+					chmod +x $out/bin/fire-tools
+				'';
+
+				meta = with pkgs.lib; {
+					homepage = "https://github.com/mrhaydendp/Fire-Tools";
+					license = licenses.mit;
+					platforms = supportedSystems;
+					maintainers = [ "mrhaydendp" ];
+				};
+			};
+		});
+	};
+}


### PR DESCRIPTION
Adding a flake lets people on linux or macos run fire-tools easily.
This resolves #48 which was a feature request / enhancement I brought up a bit ago. 

A user could run `nix run github:mrhaydendp/Fire-Tools` for the project to be downloaded and executed with all dependencies included. or replace `nix run` with `nix shell` in the above command to instead be dropped into a shell that has a `fire-tools` executable in their path to run.

A user could run `nix develop github:mrhaydendp/Fire-Tools` to be dropped into a shell that has python with all of it's dependencies for this project as well as adb.

This change doesn't really provide any benfit to windows users and doesn't really change the experience for linux / mac users who don't use the nix package manger / tools.