### PR TITLE
chore: fix missing pip install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ Follow the steps outlined in [Setup-Instructions.md](/Setup-Instructions.md) the
 # Download Latest Release & Extract, Then Run
 curl -LO https://github.com/mrhaydendp/fire-tools/releases/latest/download/Fire-Tools.zip
 unzip Fire-Tools.zip && rm Fire-Tools.zip
-cd Fire-Tools && python3 main.py
+cd Fire-Tools
+pip install -r requirements.txt
+python3 main.py
 ```
 
 **Windows Powershell:**
@@ -33,7 +35,9 @@ cd Fire-Tools && python3 main.py
 Start-BitsTransfer "https://github.com/mrhaydendp/fire-tools/releases/latest/download/Fire-Tools.zip"
 Expand-Archive Fire-Tools.zip; mv Fire-Tools\Fire-Tools\* Fire-Tools
 Remove-Item Fire-Tools.zip, Fire-Tools\Fire-Tools
-Set-Location Fire-Tools; python main.py
+Set-Location Fire-Tools; 
+pip install -r requirements.txt
+python main.py
 ```
 
 **Important Notes:**

--- a/Setup-Instructions.md
+++ b/Setup-Instructions.md
@@ -48,7 +48,8 @@ This guide will help you install the necessary dependencies to run Fire Tools on
 3. **CustomTkinter & Requests:**
     * Open PowerShell or Windows Terminal.
     * Use the `pip` package manager to install CustomTkinter:
-      ``` powershell
+
+      ```powershell
       python.exe -m pip install customtkinter requests
       ```
 
@@ -57,7 +58,8 @@ This guide will help you install the necessary dependencies to run Fire Tools on
 1. **ADB & Python:**
     * Open a Terminal window.
     * Install the ADB & Python-tk package:
-      ``` bash
+
+      ```bash
       # Ubuntu/Debian/Chrome OS Linux Container
       sudo apt install adb python3-tk
 
@@ -67,7 +69,7 @@ This guide will help you install the necessary dependencies to run Fire Tools on
       # Fedora
       sudo dnf install android-tools python3-tkinter
       ```
-      
+
 2. **CustomTkinter & Requests:**
     * Use `pip` to install CustomTkinter:
       ```bash


### PR DESCRIPTION
Add `pip install -r requirements.txt` into the readme install steps. 

Also thanks for the repo. I wrote a blog post using at https://chris.towles.me/blog/fire-tablet-and-youtube-kids


